### PR TITLE
Add command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ Allows you to specify the directory you would like the library to work in
 
 ### .patch-execute files
 A file ending in .patch-execute will be evaluated as Javascript in order to generate it's contents. The .patch-execute extension will be removed automatically during the build process. It should either export a string, or a function returning a string, or a promise returning a string. If you return a function while theres another file with the same name except without .patch-execute then the contents of the file will be passed in as a string input to your function. This can be very useful in order to generate the contents of the patched file based on the contents of the unpatched file and the code you provide in your .patch-execute file.
+
+### Command-line Interface
+
+This library also provides a command-line executable alongside this package.
+
+To use the CLI, install this package globally (e.g. using `npm install -g`). Then run:
+
+```shell
+patch-asar IN.asar PATCHDIR OUT.asar
+```
+
+The output .asar file is optional; omit it in order to overwrite the input .asar file:
+
+```shell
+patch-asar IN.asar PATCHDIR
+```

--- a/bin/patch-asar
+++ b/bin/patch-asar
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { argv, cwd, env, exit } = require('process');
+
+const args = argv.slice(2);
+
+if (args.length < 2) {
+  console.info(
+    `Usage: ${path.basename(argv[1])} IN.asar PATCHDIR [OUT.asar]`);
+  exit(1);
+}
+
+// Add patch directory’s parent to NODE_PATH to make it require-able
+const patchDir = args[1];
+const moduleSearchDir = path.dirname(path.resolve(patchDir));
+env.NODE_PATH = moduleSearchDir;
+require('module').Module._initPaths();
+
+const patchAsar = require('../source/index.js');
+
+if (args.length < 3) {
+  patchAsar(...args, { workingDirectory: cwd() });
+} else {
+  patchAsar(args[0], args[1], {
+    outputFile: args[2],
+    workingDirectory: cwd(),
+  });
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.5",
   "description": "Patch .asar archives",
   "main": "source/index.js",
+  "bin": "bin/patch-asar",
   "dependencies": {
     "asar": "^2.0.1",
     "copy-dir": "^1.2.0",


### PR DESCRIPTION
This PR adds a `patch-asar` CLI executable to be provided alongside the package.

To use the CLI, install this package globally (e.g. using `npm install -g`). Then run:

```shell
patch-asar IN.asar PATCHDIR OUT.asar
```

The output .asar file is optional; omit it in order to overwrite the input .asar file:

```shell
patch-asar IN.asar PATCHDIR
```

I have tested the executable with Node.js versions 8, 10, 12, and 20.
So I figure it works with any Node.js v8+.

Implementation notes:

- This script sets a custom `NODE_PATH` to ensure the given `PATCHDIR` can be required as a module.

- The script passes along the current working directory of the shell. This allows all arguments to be relative paths.
